### PR TITLE
feat(fv): More structured error reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,6 +978,7 @@ version = "0.1.0"
 dependencies = [
  "air",
  "bincode",
+ "regex",
  "rust_verify",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ air = { git = "https://github.com/Aristotelis2002/verus-lib.git", package = "air
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0"
 bincode = "1.0.1"
+regex = "^1.0"


### PR DESCRIPTION
Now we output jsonified structures on the stderr output which can be deserialized. Those errors now contain more information like span and secondary messages.