### PR TITLE
chore(verus-lib): Use the newest version of verus-lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 [[package]]
 name = "air"
 version = "0.1.0"
-source = "git+https://github.com/Aristotelis2002/verus-lib.git?rev=4c9858f316f6ba6016dc7ba1f1b758879cfc6897#4c9858f316f6ba6016dc7ba1f1b758879cfc6897"
+source = "git+https://github.com/Aristotelis2002/verus-lib.git?branch=synced_main#c70463ee9f1073f760dc23c289e6718f4614d8fd"
 dependencies = [
  "getopts",
  "indexmap 1.9.3",
@@ -285,6 +285,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "im"
 version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,7 +352,7 @@ dependencies = [
 [[package]]
 name = "internals_interface"
 version = "0.1.0"
-source = "git+https://github.com/Aristotelis2002/verus-lib.git?rev=4c9858f316f6ba6016dc7ba1f1b758879cfc6897#4c9858f316f6ba6016dc7ba1f1b758879cfc6897"
+source = "git+https://github.com/Aristotelis2002/verus-lib.git?branch=synced_main#c70463ee9f1073f760dc23c289e6718f4614d8fd"
 dependencies = [
  "bincode",
  "serde",
@@ -727,12 +733,13 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 [[package]]
 name = "rust_verify"
 version = "0.1.0"
-source = "git+https://github.com/Aristotelis2002/verus-lib.git?rev=4c9858f316f6ba6016dc7ba1f1b758879cfc6897#4c9858f316f6ba6016dc7ba1f1b758879cfc6897"
+source = "git+https://github.com/Aristotelis2002/verus-lib.git?branch=synced_main#c70463ee9f1073f760dc23c289e6718f4614d8fd"
 dependencies = [
  "air",
  "bincode",
  "console",
  "getopts",
+ "hex",
  "indexmap 1.9.3",
  "indicatif 0.17.11",
  "internals_interface",
@@ -741,6 +748,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "sha2",
  "sise",
  "vir",
  "win32job",
@@ -1007,7 +1015,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vir"
 version = "0.1.0"
-source = "git+https://github.com/Aristotelis2002/verus-lib.git?rev=4c9858f316f6ba6016dc7ba1f1b758879cfc6897#4c9858f316f6ba6016dc7ba1f1b758879cfc6897"
+source = "git+https://github.com/Aristotelis2002/verus-lib.git?branch=synced_main#c70463ee9f1073f760dc23c289e6718f4614d8fd"
 dependencies = [
  "air",
  "im",
@@ -1023,7 +1031,7 @@ dependencies = [
 [[package]]
 name = "vir-macros"
 version = "0.1.0"
-source = "git+https://github.com/Aristotelis2002/verus-lib.git?rev=4c9858f316f6ba6016dc7ba1f1b758879cfc6897#4c9858f316f6ba6016dc7ba1f1b758879cfc6897"
+source = "git+https://github.com/Aristotelis2002/verus-lib.git?branch=synced_main#c70463ee9f1073f760dc23c289e6718f4614d8fd"
 dependencies = [
  "proc-macro2",
  "syn 1.0.109",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-vir = { git = "https://github.com/Aristotelis2002/verus-lib.git", package = "vir", rev = "4c9858f316f6ba6016dc7ba1f1b758879cfc6897" }
-rust_verify = { git = "https://github.com/Aristotelis2002/verus-lib.git", package = "rust_verify", rev = "4c9858f316f6ba6016dc7ba1f1b758879cfc6897" }
-air = { git = "https://github.com/Aristotelis2002/verus-lib.git", package = "air", rev = "4c9858f316f6ba6016dc7ba1f1b758879cfc6897" }
+vir = { git = "https://github.com/Aristotelis2002/verus-lib.git", package = "vir", branch = "synced_main" }
+rust_verify = { git = "https://github.com/Aristotelis2002/verus-lib.git", package = "rust_verify", branch = "synced_main" }
+air = { git = "https://github.com/Aristotelis2002/verus-lib.git", package = "air", branch = "synced_main" }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0"
 bincode = "1.0.1"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.82.0"
 # channel = "nightly-2023-09-29" # (not officially supported)
 components = [ "rustc", "rust-analyzer", "rust-std", "cargo", "rustfmt", "rustc-dev", "llvm-tools"]

--- a/src/vir_optimizers.rs
+++ b/src/vir_optimizers.rs
@@ -46,6 +46,7 @@ pub fn optimize_vir_crate(verifier: &mut Verifier, vir_crate: Krate, imported: I
         unpruned_crate,
         &mut diags,
         verifier.args.no_verify,
+        verifier.args.no_cheating,
     )?;
     let reporter = Reporter::new();
     for diag in diags.drain(..) {

--- a/src/vstd_utils.rs
+++ b/src/vstd_utils.rs
@@ -4,7 +4,10 @@ use vir::messages::MessageLevel;
 
 /// Gets the Verus standard library as a Verus VIR krate
 pub fn get_imported_krates(verifier: &Verifier) -> ImportOutput {
-    match rust_verify::import_export::import_crates(&verifier.args) {
+    match rust_verify::import_export::import_crates(
+        &verifier.args,
+        verifier.import_virs_via_cargo.clone().unwrap_or_default(),
+    ) {
         Ok(imported) => imported,
         Err(err) => {
             assert!(err.spans.len() == 0);


### PR DESCRIPTION
Update to the newest version of the verus-lib dependency. In result we had to do some refactoring.